### PR TITLE
Don't slugify file names

### DIFF
--- a/mxlrc.py
+++ b/mxlrc.py
@@ -122,8 +122,8 @@ class Musixmatch:
     lrc = [f"[{line['minutes']:02d}:{line['seconds']:02d}.{line['hundredths']:02d}]{line['text']}\n" for line in lyrics]
     lines = tags + lrc
 
-    fn = filename or f"{song}"
-    filepath = os.path.join(outdir, slugify(fn)) + ".lrc"
+    fn = filename or slugify(f"{song}")
+    filepath = os.path.join(outdir, fn) + ".lrc"
     with open(filepath, "w", encoding="utf-8") as f:
       f.writelines(lines)
     print(f"Lyrics saved: {filepath}")


### PR DESCRIPTION
Slugifying file names sometimes results in a different name for the LRC file, causing applications not to recognize it/link it with the correct audio file. For example:

- 01\. Title.mp3
- 01 Title.lrc

OS-invalid characters are already stripped from the audio file's name anyway.